### PR TITLE
Fix: Avoid non-deterministic order in the converter between Maven and Gradle

### DIFF
--- a/src/main/java/com/github/platan/idea/dependencies/maven/MavenToGradleMapperImpl.java
+++ b/src/main/java/com/github/platan/idea/dependencies/maven/MavenToGradleMapperImpl.java
@@ -5,6 +5,7 @@ import com.github.platan.idea.dependencies.gradle.Exclusion;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -38,7 +39,7 @@ public class MavenToGradleMapperImpl implements MavenToGradleMapper {
     }
 
     private HashMap<String, String> createExtraOptions(MavenDependency mavenDependency) {
-        HashMap<String, String> extraOptions = new HashMap<>();
+        HashMap<String, String> extraOptions = new LinkedHashMap<>();
         if (mavenDependency.getSystemPath() != null) {
             extraOptions.put(SYSTEM_PATH, mavenDependency.getSystemPath());
         }


### PR DESCRIPTION
### Description
When converting a Maven dependency with more than one unsupported elements, the order of which the unsupported elements present in the output String can be non-deterministic. For example, the test `maven dependency with two unsupported elements` in `MavenToGradleConverterTest` may fail, as `systemPath = ...` may appear earlier than `type =...` in the output String. This non-determinism is introduced in `MavenToGradleMapperImpl.java`, where `extraOptions` are stored in a `HashMap`. (From the Javadoc: "HashMap class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.")

### Sample Failure
The HashMap and HashSet default iteration order changed between Java 7 and 8, breaking lots of unit tests. Our NonDex plugin https://github.com/TestingResearchIllinois/NonDex permutes these orders just as between Java 7 and 8, and it produces the following output in a sample run: 
```
MavenToGradleConverterTest > maven dependency with two unsupported elements FAILED
    org.spockframework.runtime.ConditionFailedWithExceptionError at MavenToGradleConverterTest.groovy:124
        Caused by: groovy.lang.MissingPropertyException at MavenToGradleConverterTest.groovy:124
```

### Suggested Fix
Use `LinkedHashMap` instead to store extra options parsed from Maven dependencies, such that the output String of the converter stays deterministic. 

